### PR TITLE
fix(PilotNames and Tests): Updated pilot name uniqueness check and co…

### DIFF
--- a/src/WK.OpenAiWrapper/Client.cs
+++ b/src/WK.OpenAiWrapper/Client.cs
@@ -43,7 +43,7 @@ internal class Client : IOpenAiClient
         using OpenAIClient client = new (_options.Value.ApiKey);
         ListResponse<AssistantResponse> assistantResponses = await client.AssistantsEndpoint.ListAssistantsAsync().ConfigureAwait(false);
         AssistantResponse? assistantResponse = assistantResponses.Items.SingleOrDefault(a => a.Name == assumptionAssistantName) ??
-                                               await client.AssistantsEndpoint.CreateAssistantAsync(new CreateAssistantRequest("gpt-4o",
+                                               await client.AssistantsEndpoint.CreateAssistantAsync(new CreateAssistantRequest("gpt-4-turbo",
                                                    assumptionAssistantName, "", Prompts.AiAssumptionPrompt)).ConfigureAwait(false);
         return assistantResponse.Id;
     }

--- a/src/WK.OpenAiWrapper/Extensions/ServiceCollectionExtensions.cs
+++ b/src/WK.OpenAiWrapper/Extensions/ServiceCollectionExtensions.cs
@@ -27,25 +27,24 @@ public static class ServiceCollectionExtensions
     
     public static IServiceCollection RegisterOpenAi(this IServiceCollection serviceCollection, IConfigurationRoot configuration, params Pilot[] pilots)
     {
-        serviceCollection.Configure<OpenAiOptions>(configuration.GetRequiredSection(OpenAiOptions.SectionName))
-            .PostConfigure<OpenAiOptions>(options =>
+        serviceCollection = serviceCollection.Configure<OpenAiOptions>(configuration.GetRequiredSection(OpenAiOptions.SectionName));
+        serviceCollection = serviceCollection.PostConfigure<OpenAiOptions>(o =>
         {
-            options.Pilots.AddRange(pilots);
-            TransferToolBuilders(options.Pilots);
+            o.Pilots.AddRange(pilots);
+            ValidatePilots(o.Pilots);
+            TransferToolBuilders(o.Pilots);
         });
-        
-        ValidatePilots(pilots);
         RegisterOpenAiClient(serviceCollection);
         return serviceCollection;
     }
     
     private static void TransferToolBuilders(IEnumerable<Pilot> pilots) => pilots.ForEach(p => p.TransferToolBuildersToTools());
     
-    private static void ValidatePilots(Pilot[] pilots)
+    private static void ValidatePilots(IEnumerable<Pilot> pilots)
     {
         //Check pilotNames are unique
         var pilotNames = pilots.Select(p => p.Name).ToList();
-        if (pilotNames.Distinct().Count() != pilotNames.Count) throw new ArgumentException("Pilot names must be unique.");
+        if (pilotNames.Distinct().Count() != pilotNames.Count) throw new ArgumentException("PilotNames names must be unique.");
     }
     
     private static void RegisterOpenAiClient(IServiceCollection serviceCollection)

--- a/src/WK.OpenAiWrapper/Models/Pilot.cs
+++ b/src/WK.OpenAiWrapper/Models/Pilot.cs
@@ -4,10 +4,26 @@ using WK.OpenAiWrapper.Helpers;
 
 namespace WK.OpenAiWrapper.Models;
 
-public record Pilot(string Name, string Instructions, string Description, string Model = "gpt-4o")
+public record Pilot(string Name, string Instructions, string Description)
 {
-    // ReSharper disable once CollectionNeverUpdated.Global
-    // ReSharper disable once ReturnTypeCanBeEnumerable.Global
+    private string? _model = "gpt-4o";
+
+    public string? Model
+    {
+        get
+        {
+            //Bugfix until the nuget 'OpenAI-DotNet' update is available and the gpt-4o can be used
+            //Todo: Delete this condition again as soon as the nuget update is available
+            if (_model == "gpt-4o")
+            {
+                return "gpt-4-turbo";
+            }
+
+            return _model;
+        }
+        set => _model = value;
+    }
+
     public ICollection<Tool> Tools { get; } = new HashSet<Tool>();
     public ICollection<ToolFunction> ToolFunctions { get; } = new HashSet<ToolFunction>();
 

--- a/src/WK.OpenAiWrapper/Models/PilotDescription.cs
+++ b/src/WK.OpenAiWrapper/Models/PilotDescription.cs
@@ -1,3 +1,3 @@
 ﻿namespace WK.OpenAiWrapper.Models;
 
-internal record PilotDescription(string Name, string Description, string Instructions, string Model, HashSet<FunctionDescription> FunctionDescriptions);
+internal record PilotDescription(string Name, string Description, string Instructions, string? Model, HashSet<FunctionDescription> FunctionDescriptions);

--- a/test/WK.OpenAiWrapper.Tests/AiFunctions/DevOpsFunctions.cs
+++ b/test/WK.OpenAiWrapper.Tests/AiFunctions/DevOpsFunctions.cs
@@ -1,9 +1,9 @@
 using System.Text;
 using WK.OpenAiWrapper.Helpers;
 
-namespace OpenAiWrapper.Tests.AiFunctions;
+namespace WK.OpenAiWrapper.Tests;
 
- public class DevOpsCommunicator
+ public class DevOpsFunctions
  {
      public async Task<string> CreateUserStory(string title, string description, 
          string acceptanceCriteria, string releaseNoteDescription)


### PR DESCRIPTION
…rrected test

Temporarily disabled the use of `gpt-4o` pending an update to the 'OpenAI-DotNet' NuGet package. Fixed a bug where the uniqueness of pilot names was checked at the correct place, i.e., after merging pilots from appsettings and manually added ones. Also corrected a faulty test.